### PR TITLE
Fix: The prop was passed so that the sidebar (mobile) is closed when a component is clicked

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -100,7 +100,7 @@ function Layout({ children }: { children: JSX.Element }) {
                 'md:flex'
               )}
             >
-              <SideBarDocs />
+              <SideBarDocs setIsActiveButtonMobile={setIsActiveButtonMobile} />
             </div>
             <div
               id="layout-content"


### PR DESCRIPTION
## Summary

The prop was passed so that the sidebar (mobile) is closed when a component is clicked

## Task

- not


## Affected sections

- src/components/Layout/Layout.tsx

## How did you test this change?

- Mannualy 
- All tests was passed ✅
