### PR TITLE
Fix(menu-docs-mobile): The component menu is left fixed when it is responsive

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -65,7 +65,7 @@ function Layout({ children }: { children: JSX.Element }) {
             alignItems="center"
             gap="2"
             className={composeClasses(
-              'py-2 px-4 md:hidden',
+              'py-2 px-4 sticky z-50 top-14 md:hidden',
               extendedPalette.cardBackground
             )}
           >


### PR DESCRIPTION
## Summary

The component menu is left fixed when it is responsive

## Task

not

## Affected sections

- src/components/Layout/Layout.tsx

## How did you test this change?

- Mannualy 
- All tests was passed ✅