### PR TITLE
doc(text-area): add new doc in textarea

### DIFF
--- a/docs/form/textarea.mdx
+++ b/docs/form/textarea.mdx
@@ -106,6 +106,19 @@ With the prop <Tag text='isRequired' /> you can mark an textArea as required. Se
 
 <TextArea isRequired label='This field is required' />" />
 
+##### <span name="floating-nav">classNameTextArea</span>
+
+With the prop <Tag text='classNameTextArea' /> you can customize the textArea, being able to enlarge it, shrink it and several other things according to your needs.
+
+<Playground className="gap-y-2">
+    <TextArea classNameTextArea='h-48' />
+</Playground>
+
+<WindowEditor codeString="import { TextArea } from 'dd360-ds'
+
+<TextArea classNameTextArea='h-48' />" />
+
+
 
 ##### <span name="floating-nav">API Reference</span>
 
@@ -126,6 +139,7 @@ With the prop <Tag text='isRequired' /> you can mark an textArea as required. Se
     { title: 'boxShadow', default: null, types: ['string'] },
     { title: 'isRequired', default: null, types: ['boolean'] },
     { title: 'className', default: null, types: ['string'] },
+    { title: 'classNameTextArea', default: null, types: ['string'] },
     ]}
 />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@algolia/autocomplete-core": "^1.8.3",
         "@docsearch/react": "^3.5.1",
         "@vercel/analytics": "^1.0.1",
-        "dd360-ds": "6.16.0",
+        "dd360-ds": "6.16.13",
         "dd360-utils": "18.1.0",
         "gray-matter": "^4.0.3",
         "i18next": "^22.4.9",
@@ -1525,9 +1525,9 @@
       "dev": true
     },
     "node_modules/dd360-ds": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/dd360-ds/-/dd360-ds-6.16.0.tgz",
-      "integrity": "sha512-qiWjtN02bx5AE2oeKZyijlnlyZZuutuCQkITTO/IBLHtJYytsg4dekrRIkt2VkNWQIGI1NRGPvi0f7H1hU5/oQ==",
+      "version": "6.16.13",
+      "resolved": "https://registry.npmjs.org/dd360-ds/-/dd360-ds-6.16.13.tgz",
+      "integrity": "sha512-sYGF0BVIImEz5zK/iwHyrxoCUWb690cPfy31vUWC5A7ORnmlyBn+m55DUbRGG7DMeATByYvWPNjN9mjZiPOkDw==",
       "dependencies": {
         "@heroicons/react": "^1.0.5",
         "@popperjs/core": "2.11.7",
@@ -8005,9 +8005,9 @@
       "dev": true
     },
     "dd360-ds": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/dd360-ds/-/dd360-ds-6.16.0.tgz",
-      "integrity": "sha512-qiWjtN02bx5AE2oeKZyijlnlyZZuutuCQkITTO/IBLHtJYytsg4dekrRIkt2VkNWQIGI1NRGPvi0f7H1hU5/oQ==",
+      "version": "6.16.13",
+      "resolved": "https://registry.npmjs.org/dd360-ds/-/dd360-ds-6.16.13.tgz",
+      "integrity": "sha512-sYGF0BVIImEz5zK/iwHyrxoCUWb690cPfy31vUWC5A7ORnmlyBn+m55DUbRGG7DMeATByYvWPNjN9mjZiPOkDw==",
       "requires": {
         "@heroicons/react": "^1.0.5",
         "@popperjs/core": "2.11.7",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@algolia/autocomplete-core": "^1.8.3",
     "@docsearch/react": "^3.5.1",
     "@vercel/analytics": "^1.0.1",
-    "dd360-ds": "6.16.0",
+    "dd360-ds": "6.16.13",
     "dd360-utils": "18.1.0",
     "gray-matter": "^4.0.3",
     "i18next": "^22.4.9",


### PR DESCRIPTION
## Summary

The possibility of adding the classNameTextArea prop was added to the TextArea component documentation.

## Task

not

## Affected sections

- docs/form/textarea.mdx
- package.json
- package-lock.json

## How did you test this change?

- Mannualy 