### PR TITLE
fix(sidebardocs): Fixed a small typo on the 'Coming' badge

### DIFF
--- a/src/components/Layout/SideBarDocs.tsx
+++ b/src/components/Layout/SideBarDocs.tsx
@@ -46,8 +46,8 @@ const BADGE_TYPES: BadgeTypes = {
     label: 'UPDATED',
     variant: 'info'
   },
-  cooming: {
-    label: 'COOMING',
+  coming: {
+    label: 'COMING',
     variant: 'warning'
   },
   deprecated: {
@@ -353,7 +353,7 @@ export const components: ComponentObjectProps = {
       {
         label: 'FeedBackBox',
         pathname: 'feed-back-box',
-        badge: BADGE_TYPES.cooming
+        badge: BADGE_TYPES.coming
       },
       {
         label: 'Filter Date',
@@ -368,12 +368,12 @@ export const components: ComponentObjectProps = {
       {
         label: 'Select Multi',
         pathname: 'select-multi',
-        badge: BADGE_TYPES.cooming
+        badge: BADGE_TYPES.coming
       },
       {
         label: 'Language',
         pathname: 'language',
-        badge: BADGE_TYPES.cooming
+        badge: BADGE_TYPES.coming
       },
       {
         label: 'Confirm Dialog',
@@ -432,7 +432,7 @@ export default function SideBarDocs({
               key={key}
             >
               {value.items.map((item) => {
-                const isTabDisabled = item.badge === BADGE_TYPES.cooming
+                const isTabDisabled = item.badge === BADGE_TYPES.coming
                 const childrenTab = (
                   <>
                     <Text


### PR DESCRIPTION
## Summary

Fix a small typo on the `Coming` badge, previously `Cooming`, as well as the property name.

## Affected sections

- src/components/Layout/SideBarDocs.tsx

## How did you test this change?

- Manually

| Before | After |
|--------|--------|
| ![screenshot-1700096011](https://github.com/dd3tech/bui-docs/assets/42563977/876b3666-1f25-4477-a635-2c965346ce33) | ![screenshot-1700095990](https://github.com/dd3tech/bui-docs/assets/42563977/75767fc5-1869-4140-96be-68bece07a075) | 






<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if merge request changes the user interface.
  How exactly did you verify that your MR solves the issue you wanted to solve?
  If you leave this empty, your MR will very likely be closed.
-->
