### PR TITLE
Feat(PageTemplate-TopPage): Add documentation top-page and page-template components

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,31 +1,23 @@
 name: SonarCloud analysis
 
 on:
-  pull_request:
-    branches: ['main']
-  workflow_dispatch:
+    pull_request:
+        branches: ['main']
+    workflow_dispatch:
 
 permissions:
-  pull-requests: read
+    pull-requests: read
 
 jobs:
-  Analysis:
-    runs-on: ubuntu-latest
+    Analysis:
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
+        steps:
+            - name: Analyze with SonarCloud
 
-      - name: Analyze with SonarCloud
-
-        uses: SonarSource/sonarcloud-github-action@de2e56b42aa84d0b1c5b622644ac17e505c9a049
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # Generate a token on Sonarcloud.io, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)
-        with:
-          args:
-            -Dsonar.projectKey=dd3tech_dd360-components-docs
-            -Dsonar.organization=dd3tech-1
+              uses: SonarSource/sonarcloud-github-action@de2e56b42aa84d0b1c5b622644ac17e505c9a049
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # Generate a token on Sonarcloud.io, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)
+              with:
+                  args: -Dsonar.projectKey=dd3tech_dd360-components-docs -Dsonar.organization=dd3tech-1

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,23 +1,31 @@
 name: SonarCloud analysis
 
 on:
-    pull_request:
-        branches: ['main']
-    workflow_dispatch:
+  pull_request:
+    branches: ['main']
+  workflow_dispatch:
 
 permissions:
-    pull-requests: read
+  pull-requests: read
 
 jobs:
-    Analysis:
-        runs-on: ubuntu-latest
+  Analysis:
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Analyze with SonarCloud
+    steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
 
-              uses: SonarSource/sonarcloud-github-action@de2e56b42aa84d0b1c5b622644ac17e505c9a049
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information
-                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # Generate a token on Sonarcloud.io, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)
-              with:
-                  args: -Dsonar.projectKey=dd3tech_dd360-components-docs -Dsonar.organization=dd3tech-1
+      - name: Analyze with SonarCloud
+
+        uses: SonarSource/sonarcloud-github-action@de2e56b42aa84d0b1c5b622644ac17e505c9a049
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # Generate a token on Sonarcloud.io, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)
+        with:
+          args:
+            -Dsonar.projectKey=dd3tech_dd360-components-docs
+            -Dsonar.organization=dd3tech-1

--- a/docs/layout/page-template.mdx
+++ b/docs/layout/page-template.mdx
@@ -1,0 +1,348 @@
+---
+product: dd360-ds
+title: React PageTemplate component
+components: PageTemplate
+---
+
+<br id='top' />
+<br />
+
+<Label>Layout</Label>
+
+# <HeaderDocCustom title="PageTemplate" pathUrl="layout-page-template--page-template" />
+
+
+The `PageTemplate` is a flexible layout component that structures a page's content, including search bars, filters, action buttons, and result displays. It allows easy customization of the header, footer, and interactive elements, ensuring a consistent and user-friendly interface.
+
+<br />
+<br />
+##### <span name="floating-nav">Import</span>
+
+<WindowEditor codeString="import { PageTemplate } from 'dd360-ds'" />
+<WindowEditor codeString="import PageTemplate from 'dd360-ds/PageTemplate'" />
+
+<br />
+<br />
+##### <span name="floating-nav">Usage</span>
+
+<Playground >
+   <PageTemplate title={{label:'PageTemplate Component'}}>Children</PageTemplate>
+</Playground>
+
+<WindowEditor codeString={`import { PageTemplate } from "dd360-ds"
+
+<PageTemplate title={{label:'PageTemplate Component'}}>Children</PageTemplate>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">Children</span>
+
+With the prop <TagDocs text='Children' />, you can pass any valid React node to be rendered as the main content inside the `PageTemplate` component. This allows you to define custom content, such as text, components, or elements, within the layout.
+
+
+<Playground >
+     <PageTemplate title={{label:'PageTemplate Component'}}>Children</PageTemplate>
+</Playground>
+
+<WindowEditor codeString={`import { PageTemplate } from "dd360-ds"
+
+<PageTemplate title={{label:'PageTemplate Component'}}>Children</PageTemplate>
+`} />
+
+<br />
+<br />
+
+
+
+##### <span name="floating-nav">Search</span>
+
+With the prop <TagDocs text='Search' />, you can pass an object with properties like `value`, `onChange`, `placeholder`, and `disabled` to render a search bar within the `PageTemplate` component. This allows users to search and filter content directly from the header.
+
+<Playground>
+     <PageTemplate title={{label:'PageTemplate Component'}} 
+     search={{onchange:()=>alert('searching...'),value:'Search',placeholder:'Search',disabled:true}}
+     >Children</PageTemplate>
+</Playground>
+
+<WindowEditor codeString={`import { PageTemplate } from "dd360-ds"
+
+  <PageTemplate 
+  title={{label:'PageTemplate Component'}} 
+  search={{onchange:()=>alert('searching...'),
+  value:'Search',placeholder:'Search',disabled:true}}>
+  Children</PageTemplate>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">Results</span>
+
+With the prop <TagDocs text='Results' />, you can pass an object with properties like `number` and `label` to display the number of results and a custom label within the `PageTemplate` component. This helps users quickly understand the amount of available data.
+
+<Playground>
+     <PageTemplate title={{label:'PageTemplate Component'}} 
+     search={{onchange:()=>alert('searching...'),value:'Search',placeholder:'Search',disabled:true}}
+     results={{number:4,label:'results'}}
+     >Children</PageTemplate>
+</Playground>
+
+<WindowEditor codeString={`import { PageTemplate } from "dd360-ds"
+
+  <PageTemplate 
+  title={{label:'PageTemplate Component'}} 
+  results={{number:4,label:'results'}}>
+  Children
+  </PageTemplate>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">ViewToggle</span>
+
+With the prop <TagDocs text='ViewToggle' />, you can pass an object with properties like `onToggle`, `isActive`, `iconOff`, and `iconOn` to enable a toggle button within the `PageTemplate` component. This allows users to switch between different views, such as list or grid.
+
+<Playground>
+     <PageTemplate title={{label:'PageTemplate Component'}} 
+     search={{onchange:()=>alert('searching...'),value:'Search',placeholder:'Search',disabled:true}}
+     results={{number:4,label:'results'}}
+     viewToggle= {{
+     onToggle: () => alert('View toggled'),
+     isActive: false,
+     iconOff: <span>A</span>,
+     iconOn: <span>B</span>}
+  }
+     >Children</PageTemplate>
+</Playground>
+
+<WindowEditor codeString={`import { PageTemplate } from "dd360-ds"
+
+  <PageTemplate 
+  title={{label:'PageTemplate Component'}} 
+  results={{number:4,label:'results'}}
+  viewToggle= {{
+     onToggle: () => alert('View toggled'),
+     isActive: false,
+     iconOff: <span>A</span>,
+     iconOn: <span>B</span>}
+  }>
+  Children
+  </PageTemplate>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">Filters</span>
+
+With the prop <TagDocs text='Filters' />, With the prop <TagDocs text='Filters' />, you can pass an object to define filtering options within the `PageTemplate` component. This allows you to add dropdown checkboxes with customizable options, labels, and callback functions for submission and closing.
+
+<Playground className='h-72'>
+     <PageTemplate title={{label:'PageTemplate Component'}} 
+     filters={{ dropdownCheckbox: [{ cancelText: 'Cancel',
+        confirmText: 'Confirm',
+        onSubmit: () => alert('Checkbox filter submitted'),
+        onClose: () => alert('Checkbox filter closed'),
+        title: 'Filter Options',
+        align: 'left',
+        options: [ { label: 'Option 1', value: 'option1' }, { label: 'Option 2', value: 'option2' },{ label: 'Option 3', value: 'option3' }
+        ],
+        allText: 'Select All',
+        initialValue: ['option1']
+      }
+     ]}}
+     >Children</PageTemplate>
+</Playground>
+
+<WindowEditor codeString={`import { PageTemplate } from "dd360-ds"
+
+  <PageTemplate 
+   title={{label:'PageTemplate Component'}} 
+   filters={{ dropdownCheckbox: [{ cancelText: 'Cancel',
+        confirmText: 'Confirm',
+        onSubmit: () => alert('Checkbox filter submitted'),
+        onClose: () => alert('Checkbox filter closed'),
+        title: 'Filter Options',
+        align: 'left',
+        options: [ 
+        { label: 'Option 1', value: 'option1' }, 
+        { label: 'Option 2', value: 'option2' },
+        { label: 'Option 3', value: 'option3' }
+        ],
+        allText: 'Select All',
+        initialValue: ['option1']
+      }
+     ]}}>
+  Children
+  </PageTemplate>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">ClearFilters</span>
+
+With the prop <TagDocs text='ClearFilters' />, you can pass an object to define a button or action to reset the filters applied within the `PageTemplate` component. This allows you to customize the button label and define a callback function that executes when the button is clicked.
+
+<Playground className='h-72'>
+     <PageTemplate title={{label:'PageTemplate Component'}} 
+     filters={{ dropdownCheckbox: [{ cancelText: 'Cancel',
+        confirmText: 'Confirm',
+        onSubmit: () => alert('Checkbox filter submitted'),
+        onClose: () => alert('Checkbox filter closed'),
+        title: 'Filter Options',
+        align: 'left',
+        options: [ { label: 'Option 1', value: 'option1' }, { label: 'Option 2', value: 'option2' },{ label: 'Option 3', value: 'option3' }
+        ],
+        allText: 'Select All',
+        initialValue: ['option1']
+      }
+     ]}}
+    clearFilters={{
+    label: 'Restore',
+    onClick: () => alert('Filters have been reset')
+    }}
+     >Children</PageTemplate>
+</Playground>
+
+<WindowEditor codeString={`import { PageTemplate } from "dd360-ds"
+
+  <PageTemplate 
+   title={{label:'PageTemplate Component'}} 
+   filters={{ dropdownCheckbox: [{ cancelText: 'Cancel',
+        confirmText: 'Confirm',
+        onSubmit: () => alert('Checkbox filter submitted'),
+        onClose: () => alert('Checkbox filter closed'),
+        title: 'Filter Options',
+        align: 'left',
+        options: [ 
+        { label: 'Option 1', value: 'option1' }, 
+        { label: 'Option 2', value: 'option2' },
+        { label: 'Option 3', value: 'option3' }
+        ],
+        allText: 'Select All',
+        initialValue: ['option1']
+      }
+     ]}}
+    clearFilters={{
+    label: 'Restore',
+    onClick: () => alert('Filters have been reset')
+    }}>
+  Children
+  </PageTemplate>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">CallToAction</span>
+
+With the prop <TagDocs text='CallToAction' />, you can pass an object to define a customizable button within the `PageTemplate` component. This allows you to specify a label, an icon, and an `onClick` event handler to define the action that will be executed when the button is clicked.
+
+<Playground className='h-72'>
+     <PageTemplate title={{label:'PageTemplate Component'}} 
+     filters={{ dropdownCheckbox: [{ cancelText: 'Cancel',
+        confirmText: 'Confirm',
+        onSubmit: () => alert('Checkbox filter submitted'),
+        onClose: () => alert('Checkbox filter closed'),
+        title: 'Filter Options',
+        align: 'left',
+        options: [ { label: 'Option 1', value: 'option1' }, { label: 'Option 2', value: 'option2' },{ label: 'Option 3', value: 'option3' }
+        ],
+        allText: 'Select All',
+        initialValue: ['option1']
+      }
+     ]}}
+     callToAction={{
+        onClick: () => alert('call to action clicked'),
+        label: 'Call to action',
+        icon: "CalendarIcon"  }}
+     >Children</PageTemplate>
+</Playground>
+
+<WindowEditor codeString={`import { PageTemplate } from "dd360-ds"
+
+  <PageTemplate 
+   title={{label:'PageTemplate Component'}} 
+   filters={{ dropdownCheckbox: [{ cancelText: 'Cancel',
+        confirmText: 'Confirm',
+        onSubmit: () => alert('Checkbox filter submitted'),
+        onClose: () => alert('Checkbox filter closed'),
+        title: 'Filter Options',
+        align: 'left',
+        options: [ 
+        { label: 'Option 1', value: 'option1' }, 
+        { label: 'Option 2', value: 'option2' },
+        { label: 'Option 3', value: 'option3' }
+        ],
+        allText: 'Select All',
+        initialValue: ['option1']
+      }
+     ]}}
+   callToAction={{
+        onClick: () => alert('call to action clicked'),
+        label: 'Call to action',
+        icon: "CalendarIcon"  }}>
+  Children
+  </PageTemplate>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">ArrowSelector</span>
+
+With the prop <TagDocs text='ArrowSelector' />, you can pass an object to display left and right navigation buttons within the `PageTemplate` component. This allows you to define a label and set `onClickLeft` and `onClickRight` event handlers to execute custom actions when the user clicks the left or right buttons.
+
+<Playground >
+     <PageTemplate title={{label:'PageTemplate Component'}} 
+     results={{number:4,label:'results'}}
+     arrowSelector={ {
+    label: 'Action Move',
+    onClickLeft: () => alert('Navigated left'),
+    onClickRight: () => alert('Navigated right')
+    }}
+     >Children</PageTemplate>
+</Playground>
+
+<WindowEditor codeString={`import { PageTemplate } from "dd360-ds"
+
+  <PageTemplate 
+   title={{label:'PageTemplate Component'}} 
+    results={{number:4,label:'results'}}
+    arrowSelector={ {
+    label: 'Move to Month',
+    onClickLeft: () => alert('Navigated left'),
+    onClickRight: () => alert('Navigated right')
+    }}
+  Children
+  </PageTemplate>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">API Reference</span>
+
+<CustomTableDocs
+    dataTable={[
+        { title: 'children', default: null, types: ['React.React.Node'] },
+        { title: 'footer', default: null, types: ['React.React.Node'],},
+        { title: 'search', default: null, types: ['FilterSearchProps'],},
+        { title: 'results', default: null, types: ['FilterLabelProps'],},
+        { title: 'viewToggle', default: null, types: ['ToggleButtonProps'],},
+        { title: 'filters', default: null, types: ['FiltersProps'],},
+        { title: 'clearFilters', default: null, types: ['ClearFiltersProps'],},
+        { title: 'callToAction', default: null, types: ['CallToActionProps'],},
+        { title: 'arrowSelector', default: null, types: ['ArrowSelectorProps'],},
+        { title: 'role', default: null, types: ['string'],},
+        { title: 'hiddenFilterBar', default: null, types: ['boolean'],},
+         // Note about additional props extending from TopPageProps
+        { title: '...otherProps', default: null, types: ['TopPageProps'], description: 'This component also accepts all props that extend from the TopPage component.' },
+    ]}
+/>
+
+<BackAndForwardController />

--- a/docs/layout/top-page.mdx
+++ b/docs/layout/top-page.mdx
@@ -1,0 +1,225 @@
+---
+product: dd360-ds
+title: React TopPage component
+components: TopPage
+---
+
+<br id='top' />
+<br />
+
+<Label>Layout</Label>
+
+# <HeaderDocCustom title="TopPage" pathUrl="layout-top-page--top-page" />
+
+
+The `TopPage` component is responsible for organizing and displaying key elements at the top of a page. It includes the page title, breadcrumbs for easy navigation, and a "last updated" date. Additionally, it can show action buttons with labels, icons, and click handlers for quick actions. It also supports a customizable icon button for additional actions and navigation tabs for section switching. This component helps in creating a clean, accessible, and user-friendly interface.
+
+<br />
+<br />
+##### <span name="floating-nav">Import</span>
+
+<WindowEditor codeString="import { TopPage } from 'dd360-ds'" />
+<WindowEditor codeString="import TopPage from 'dd360-ds/TopPage'" />
+
+<br />
+<br />
+##### <span name="floating-nav">Usage</span>
+
+<Playground >
+   <TopPage title={{label:'TopPage Component'}}/>
+</Playground>
+
+<WindowEditor codeString={`import { TopPage } from "dd360-ds"
+
+<TopPage title={{label:'TopPage Component'}}/>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">Description</span>
+
+With the prop <TagDocs text='Description' /> allows you to display a brief text below the title on the TopPage component. It accepts a string value and is useful for providing additional context or information related to the page.
+
+
+<Playground >
+   <TopPage title={{label:'TopPage Component'}} description="TopPage Component Description"/>
+</Playground>
+
+<WindowEditor codeString={`import { TopPage } from "dd360-ds"
+
+  <TopPage
+    title={{label:'TopPage Component'}} description="TopPage Component Description" />
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">OptionsBreadcrumbs</span>
+
+With the prop <TagDocs text='OptionsBreadcrumbs' /> allows allows you to configure the breadcrumb navigation for the TopPage component. It accepts an object with an options array, where each breadcrumb can include a name (the display text) and a to function (which defines the redirect behavior when clicked). Additionally, this prop offers more customization options like separator and isLoading for more control over the breadcrumb rendering. You can check the full list of available options in the API Reference.
+
+
+<Playground >
+   <TopPage title={{label:'TopPage Component'}} optionsBreadcrumbs={{options:[{name:'Home',to:()=>console.log('redirect to Home')},{name:'Dashboard',to:()=>console.log('redirect to Dashboard')}]}}/>
+</Playground>
+
+<WindowEditor codeString={`import { TopPage } from "dd360-ds"
+
+  <TopPage
+    title={{label:'TopPage Component'}} 
+    optionsBreadcrumns={
+    {options:[
+    {name:'Home',to:()=>console.log('redirect to Home')},
+    {name:'Dashboard',to:()=>console.log('redirect to Dashboard')}
+    ]}
+    }/>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">LastUpdate</span>
+
+With the prop <TagDocs text='LastUpdate' /> allows you to display the last update date on the TopPage component. It accepts an object with a translation value ('en' or 'es') to format the date accordingly, and a date value as a Date object. This helps provide users with clear information about the last update status.
+
+
+<Playground >
+   <TopPage title={{label:'TopPage Component'}} lastUpdate={{translation:'en',date:new Date()}}/>
+</Playground>
+
+<WindowEditor codeString={`import { TopPage } from "dd360-ds"
+
+  <TopPage
+    title={{label:'TopPage Component'}} lastUpdate={{tranlation:'en',date:new Date()}} />
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">CallToActionsButtons</span>
+
+With the prop <TagDocs text='CallToActionsButtons' /> allows you to display a list of action buttons on the TopPage component. Each button accepts a label (string) to define the button text, an onClick (function) to handle the button action, and a variant (string) to customize the button style. You can further customize the buttons. You can check the full list of available options in the API Reference.
+
+
+<Playground >
+   <TopPage title={{label:'TopPage Component'}} callToActionsButtons={[{
+      label: 'Save Changes',
+      onClick: () => console.log('Save changes action'),
+      variant: 'primary',
+    }]}/>
+</Playground>
+
+<WindowEditor codeString={`import { TopPage } from "dd360-ds" 
+
+  <TopPage
+    title={{label:'TopPage Component'}} 
+    callToActionsButtons={{
+      label: 'Save Changes',
+      onClick: () => console.log('Save changes action'),
+      variant: 'primary' ,
+    }} />
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">ActionIcon</span>
+
+With the prop <TagDocs text='ActionIcon' />, you can display a list of action icons on the **TopPage** component. Each icon accepts a `titleIcon` (ReactNode) to define the icon to display, an `onClick` (function) to handle the action when clicked, and an `isSelected` (boolean) to control the active state of the icon. You can further customize the icons and their behavior. You can check the full list of available options in the API Reference.
+
+
+
+<Playground >
+   <TopPage title={{label:'TopPage Component'}} actionIcon={[{
+    titleIcon: <DynamicHeroIcon icon="TagIcon" className="w-5 h-5" />,
+    onClick: () => console.log('prev state'),
+    isSelected: false
+    }]}/>
+</Playground>
+
+<WindowEditor codeString={`import { TopPage } from "dd360-ds" 
+import DynamicHeroIcon from 'dd360-ds/DynamicHeroIcon'
+
+  <TopPage
+    title={{label:'TopPage Component'}} 
+    actionIcon={[{
+     itleIcon: <DynamicHeroIcon icon="TagIcon" className="w-5 h-5" />,
+    onClick: () => console.log('prev state'),
+    isSelected: false
+    }]}/>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">Tabs</span>
+
+With the prop <TagDocs text='Tabs' />, you can display a list of tabs on the **TopPage** component. The `tabs` prop accepts a `value` (number) to define the currently selected tab, a `setValue` (function) to handle tab selection changes, and an `items` array where each item includes a `label` (string) to define the tab name and `content` (ReactNode) to display the corresponding content. You can check the full list of available options in the API Reference.
+
+
+<Playground >
+   <TopPage title={{label:'TopPage Component'}} tabs={{
+    value: 0,
+    setValue: (value) => console.log('Tab changed to', value),
+    items: [
+      { label: 'Tab 1', content: <div>Content for Tab 1</div> },
+      { label: 'Tab 2', content: <div>Content for Tab 2</div>, disabled:true }
+    ]
+    }}/>
+</Playground>
+
+<WindowEditor codeString={`import { TopPage } from "dd360-ds" 
+
+  <TopPage
+    title={{label:'TopPage Component'}} 
+    tabs={{
+    value: 0,
+    setValue: (value) => console.log('Tab changed to', value),
+    items: [
+      { label: 'Tab 1', content: <div>Content for Tab 1</div> },
+      { label: 'Tab 2', content: <div>Content for Tab 2</div>, disabled:true }
+    ]
+    }}/>
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">ClassNameHeader</span>
+
+With the prop <TagDocs text='ClassNameHeader' />, you can customize the styling of the header in the **TopPage** component using a custom CSS class. This allows you to apply background colors, padding, margins, and other styling properties to match the design of your application.
+
+
+<Playground >
+   <TopPage title={{label:'TopPage Component'}} classNameHeader='bg-indigo-200'/>
+</Playground>
+
+<WindowEditor codeString={`import { TopPage } from "dd360-ds" 
+
+  <TopPage
+    title={{label:'TopPage Component'}} 
+    classNameHeader='bg-indigo-200'
+ />
+`} />
+
+<br />
+<br />
+
+##### <span name="floating-nav">API Reference</span>
+
+<CustomTableDocs
+    dataTable={[
+        { title: 'title', default: null, types: ['{ label: string, isLoading: boolean}'],required:true },
+        { title: 'description', default: null, types: ['string'],},
+        { title: 'optionsBreadcrumbs', default: null, types: ['{ options: Array<BreadcrumbsProps["options"]>, separator?: BreadcrumbsProps["separator"], isLoading?: BreadcrumbsProps["isLoading"] }'],},
+        { title: 'lastUpdate', default: null, types: ['{ translation: "es"|"en", date: Date }'],},
+        { title: 'callToActionsButtons', default: null, types: ['Array<{ label: string, onClick: () => void, icon?: React.ReactNode, variant: "primary" | "secondary" | "tertiary", isDisabled?: boolean, isLoading?: boolean, role?: string }>'],},
+        { title: 'actionIcon', default: null, types: ['{ titleIcon?: React.ReactNode, onClick?: ((e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void, isSelected?: boolean, isDisabled?: boolean | "secondary" | "tertiary", isDisabled?: boolean, role?: string }'],},
+        { title: 'tabs', default: null, types: ['{ value: number, setValue: React.Dispatch<React.SetStateAction<number>>, items: Array<{label:string,disabled:boolean,hidden:boolean,toolTipProps:["TooltipProps"]}>}'],},
+        { title: 'classNameHeader', default: null, types: ['string'],},
+        
+    ]}
+/>
+
+<BackAndForwardController />

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@algolia/autocomplete-core": "^1.8.3",
         "@docsearch/react": "^3.5.1",
         "@vercel/analytics": "^1.0.1",
-        "dd360-ds": "6.26.17",
+        "dd360-ds": "6.35.1",
         "dd360-utils": "18.1.0",
         "gray-matter": "^4.0.3",
         "i18next": "^22.4.9",
@@ -1525,9 +1525,10 @@
       "dev": true
     },
     "node_modules/dd360-ds": {
-      "version": "6.26.17",
-      "resolved": "https://registry.npmjs.org/dd360-ds/-/dd360-ds-6.26.17.tgz",
-      "integrity": "sha512-nP37NeJqqyj8/k4EVu60+2efFS7XdUQsuLMyOGdBVEM3j/XFgc7y+PNwuUM6TyNF95v31HkFQyYTM8Jz1FeK8A==",
+      "version": "6.35.1",
+      "resolved": "https://registry.npmjs.org/dd360-ds/-/dd360-ds-6.35.1.tgz",
+      "integrity": "sha512-tzo2gk3fLI1D44uCv3FM8KbBCGbLutdJWpKETxROPwD53EGzPJJVvAvk+ah/zpLi8fo/P9l1oI8LoqY102c4OQ==",
+      "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^1.0.5",
         "@popperjs/core": "2.11.7",
@@ -8005,9 +8006,9 @@
       "dev": true
     },
     "dd360-ds": {
-      "version": "6.26.17",
-      "resolved": "https://registry.npmjs.org/dd360-ds/-/dd360-ds-6.26.17.tgz",
-      "integrity": "sha512-nP37NeJqqyj8/k4EVu60+2efFS7XdUQsuLMyOGdBVEM3j/XFgc7y+PNwuUM6TyNF95v31HkFQyYTM8Jz1FeK8A==",
+      "version": "6.35.1",
+      "resolved": "https://registry.npmjs.org/dd360-ds/-/dd360-ds-6.35.1.tgz",
+      "integrity": "sha512-tzo2gk3fLI1D44uCv3FM8KbBCGbLutdJWpKETxROPwD53EGzPJJVvAvk+ah/zpLi8fo/P9l1oI8LoqY102c4OQ==",
       "requires": {
         "@heroicons/react": "^1.0.5",
         "@popperjs/core": "2.11.7",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@algolia/autocomplete-core": "^1.8.3",
     "@docsearch/react": "^3.5.1",
     "@vercel/analytics": "^1.0.1",
-    "dd360-ds": "6.26.17",
+    "dd360-ds": "6.35.1",
     "dd360-utils": "18.1.0",
     "gray-matter": "^4.0.3",
     "i18next": "^22.4.9",

--- a/src/components/Layout/SideBarDocs.tsx
+++ b/src/components/Layout/SideBarDocs.tsx
@@ -104,16 +104,16 @@ export const components: ComponentObjectProps = {
         pathname: 'card'
       },
       {
-        label: 'Download Card',
-        pathname: 'card-download'
-      },
-      {
         label: 'Container',
         pathname: 'container'
       },
       {
         label: 'Divider',
         pathname: 'divider'
+      },
+      {
+        label: 'Download Card',
+        pathname: 'card-download'
       },
       {
         label: 'Flex',
@@ -132,12 +132,20 @@ export const components: ComponentObjectProps = {
         pathname: 'overflow'
       },
       {
+        label: 'PageTemplate',
+        pathname: 'page-template'
+      },
+      {
         label: 'Row',
         pathname: 'row'
       },
       {
         label: 'SideBar',
         pathname: 'sidebar'
+      },
+      {
+        label: 'TopPage',
+        pathname: 'top-page'
       },
       {
         label: 'Wrapper',


### PR DESCRIPTION
## Summary

Add documentation top-page and page-template components

## Task

- https://dd360.atlassian.net/jira/software/projects/PD/boards/82?assignee=6397d027fbf54baf29036449&selectedIssue=PD-1230

## Affected sections

- src/components/Layout/SideBarDocs.tsx
- docs/layout/page-template.mdx
- docs/layout/top-page.mdx
- package-lock.json
- package.json

## How did you test this change?

- Manually tested